### PR TITLE
Kh fixes

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,3 +8,6 @@ db.type=postgres
 server.error.include-stacktrace=never
 server.error.include-message=always
 server.port=8080
+
+#bootstrap.dir=./src/test/resources/kds_new
+#bootstrap.recursively-open-directories=true


### PR DESCRIPTION
fix to support multiple fhir resource mapped to same archetype
Example
Condition resource mapped to Problem Diagnosis archetype
Observation resource mapped to Problem Diagnosis archetype

Issue: 
If the template has Problem diagnosis as cardinal 0..*
Observation data was overwriting Condition data as the index for Observationalso starts from zero