### PR TITLE
make db reachable outside container

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,6 +13,8 @@ services:
       DB_TYPE: postgres
   db:
     image: postgres:15
+    ports:
+      - "5432:5432"
     environment:
       POSTGRES_DB: openfhir
       POSTGRES_USER: postgres


### PR DESCRIPTION
Adding a standard port for postgres.
This allowed me to inspect the database (from Dbweaver) which helped troubleshooting.
The downside is it might collide with a currently running database at that port. But that's also true for the 8080 port for openfhir itself. 