### PR TITLE
fix(validator): skip AQL parsing for $openEhrContext

### DIFF
--- a/src/main/java/com/medblocks/openfhir/util/FhirConnectValidator.java
+++ b/src/main/java/com/medblocks/openfhir/util/FhirConnectValidator.java
@@ -121,6 +121,10 @@ public class FhirConnectValidator {
             aqlPath = "";
         }
         else{
+            // Paths starting with $openEhrContext are not AQL object paths and should be ignored by the validator
+            if (mapping.getWith().getOpenehr().startsWith(FhirConnectConst.OPENEHR_CONTEXT_FC)) {
+                return "";
+            }
             aqlPath = mapping.getWith().getOpenehr().replace(FhirConnectConst.OPENEHR_ARCHETYPE_FC,"").replace(FhirConnectConst.OPENEHR_COMPOSITION_FC,"")
                     .replace(FhirConnectConst.REFERENCE,"").replace(FhirConnectConst.OPENEHR_ROOT_FC, "");
         }

--- a/src/test/java/com/medblocks/openfhir/util/FhirConnectValidatorTest.java
+++ b/src/test/java/com/medblocks/openfhir/util/FhirConnectValidatorTest.java
@@ -2,13 +2,35 @@ package com.medblocks.openfhir.util;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.medblocks.openfhir.fc.schema.model.FhirConnectModel;
+import com.medblocks.openfhir.fc.schema.model.Mapping;
+import com.medblocks.openfhir.fc.schema.model.With;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 
 class FhirConnectValidatorTest {
 
+    @Test
+    void validateSkipsOpenEhrContextMappings() {
+        final FhirConnectValidator validator = new FhirConnectValidator();
+        final FhirConnectModel model = new FhirConnectModel();
+
+        final List<Mapping> mappings = new ArrayList<>();
+        final Mapping mapping = new Mapping();
+        final With with = new With();
+        with.setFhir("$resource.subject.reference");
+        with.setOpenehr("$openEhrContext.$ehr");
+        mapping.setWith(with);
+        mapping.setName("patient");
+        mappings.add(mapping);
+        model.setMappings(mappings);
+
+        final List<String> errors = validator.validateFhirConnectModel(model);
+        Assert.assertNotNull(errors);
+        Assert.assertTrue("Expected no AQL validation errors for $openEhrContext mappings", errors.isEmpty());
+    }
     @Test
     void validateAgainstModelSchema() throws IOException {
         final ObjectMapper yaml = OpenFhirTestUtility.getYaml();


### PR DESCRIPTION
# Fix: Skip AQL parsing for `$openEhrContext.*` mappings in validator

## Context
The validator was incorrectly attempting to parse `with.openehr` values starting with `$openEhrContext` (e.g., `$openEhrContext.$ehr`) using `AqlObjectPath.parse`.  
Since `$openEhrContext.*` are not AQL object paths, this caused parse errors at the leading `$` token.  

At runtime, `FhirToOpenEhr` already **skips** these mappings. The validator now mirrors that behavior.

---

## What Changed
- **`FhirConnectValidator.java`**
  - Updated `formatPath(...)` to return `""` when `with.openehr` starts with `FhirConnectConst.OPENEHR_CONTEXT_FC` (`$openEhrContext`).
  - This skips AQL parsing for `$openEhrContext.*` entries.
  - Preserved existing handling for `$archetype`, `$composition`, `$reference`, `$openehrRoot` tokens, and leading-slash trimming.
  - No changes to schema validation logic.

- **`FhirConnectValidatorTest.java`**
  - Added `validateSkipsOpenEhrContextMappings()`.
  - Constructs a minimal model with `with.openehr="$openEhrContext.$ehr"`.
  - Asserts that no AQL validation errors are raised.

---

## Why This Is Correct
- `$openEhrContext.*` are **context tokens**, not AQL object paths.
- Parsing them as AQL is invalid and inconsistent with runtime behavior.
- `FhirToOpenEhr.createHelpers(...)` already skips them (`with.getOpenehr().startsWith("$openEhrContext")`).
- Validator behavior is now aligned with domain semantics and runtime.

---

## Tests
- ✅ New regression test (`validateSkipsOpenEhrContextMappings`) passes.
- ✅ Full unit test suite passes (`mvn test`).
- ✅ Verified no parse errors when manually validating a model with `$openEhrContext.$ehr`.

---

## Backward Compatibility
- **Non-breaking**: only affects `$openEhrContext.*` mappings.
- All other mappings and token replacements remain unchanged.

---

## Risk / Impact
- **Low risk**:  
  - Only skips AQL parsing for explicitly non-AQL tokens.  
  - No impact on schema validation or runtime mapping behavior.  

- **Nuance**: validator still processes children under a `$openEhrContext` parent, while runtime skips the entire subtree.  
  - This can be addressed in a follow-up.